### PR TITLE
Fix volume path for PostgreSQL data

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -134,7 +134,7 @@ services:
     networks:
       - amass
     volumes:
-      - ./assetdb/postgres:/var/lib/postgresql/data:rw
+      - ./assetdb/postgres:/var/lib/postgresql:rw
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
Since Postgres 18 changes were made in the volume mount path.

See also: https://hub.docker.com/_/postgres/#pgdata

I do think this will also cause problems when updating to new PG version, but without this it is not working at all.