### PR TITLE
Fixed assetdb failing - Postgres 18

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -134,7 +134,7 @@ services:
     networks:
       - amass
     volumes:
-      - ./assetdb/postgres:/var/lib/postgresql/data:rw
+      - ./assetdb/postgres:/var/lib/postgresql/18/data:rw
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
Error: in 18+, these Docker images are configured to store database data in a
format which is compatible with "pg_ctlcluster" (specifically, using
major-version-specific directory names).  This better reflects how
PostgreSQL itself works, and how upgrades are to be performed.
See also https://github.com/docker-library/postgres/pull/1259⁠
Counter to that, there appears to be PostgreSQL data in:
/var/lib/postgresql/data (unused mount/volume)
This is usually the result of upgrading the Docker image without
upgrading the underlying database using "pg_upgrade" (which requires both
versions).
The suggested container configuration for 18+ is to place a single mount
at /var/lib/postgresql which will then place PostgreSQL data in a
subdirectory, allowing usage of "pg_upgrade --link" without mount point
boundary issues.
See https://github.com/docker-library/postgres/issues/37⁠ for a (long)
discussion around this process, and suggestions for how to do so.

Fix :
changed the mount point from `./assetdb/postgres:/var/lib/postgresql/data:rw` to `./assetdb/postgres:/var/lib/postgresql/18/data:rw` 