### PR TITLE
Add credential management, config-init service, and README overhaul

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-# Change Me!
-POSTGRES_PASSWORD=postgres
-AMASS_DB=assetdb
-AMASS_USER=amass
-# Change Me!
-AMASS_PASSWORD=amass4OWASP

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,7 @@
+# PostgreSQL root password
+POSTGRES_PASSWORD=postgres # Change Me!
+# Amass Database
+DB_SERVER=postgres         # Optional change to neo4j
+AMASS_DB=assetdb
+AMASS_USER=amass
+AMASS_PASSWORD=amass4OWASP # Change Me!

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.env  
+config/config.yaml
+config/datasources.yaml
+assetdb/*
+data/*
+logs/*
+config/logs/log/
+config/logs/syslog-ng.ctl
+config/logs/syslog-ng.persist
+config/logs/syslog-ng.pid
+.claude/*
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -24,32 +24,128 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 
 ### Configure the Compose Environment
 
-1. Recommended: open the `.env` file and assign a new POSTGRES_PASSWORD and AMASS_PASSWORD. Save. **This cannot be performed after you start the Docker Compose and the database has been created.**
-2. Make desired changes to the `config.yaml` file, being sure to replace the password field of the `database` value with the password you assigned as your AMASS_PASSWORD. Save.
-3. Optional: update your `datasources.yaml` file by uncommenting data sources and adding account credentials.
+1. Copy the template to create your environment file: `cp .env.template .env && chmod 0600 .env` — then edit `.env` and set a strong `POSTGRES_PASSWORD` and `AMASS_PASSWORD`. You may also change `AMASS_DB` and `AMASS_USER` if desired. **Credentials cannot be changed after the database has been created.**
+2. PostgreSQL is the default database. To use Neo4j instead, set `DB_SERVER=neo4j` in `.env`. Database credentials and selection are handled automatically at container startup — no manual editing of `config/config.yaml` is needed.
+3. Optional: update `config/datasources.yaml` by uncommenting data sources and adding account credentials.
 
 ### Build the Docker Images
 
-1. Your Amass framework is now configured and ready to be built. Docker Compose will build the required images and start them correctly when you perform your first `amass` command execution.
-2. Type the following to get started: `docker compose run --rm amass enum -d owasp.org`
-3. If the build process times out, simply execute the command again to resume.
+1. Your Amass framework is now configured and ready to be built. Build and start all services with: `docker compose up -d`
+2. If the build process times out, simply execute the command again to resume.
 
 ### Details about the Docker Environment
 
 * All persistent data used exists on your host in the local repo root directory.
 * The `assetdb` is a [PostgreSQL](https://github.com/postgres/postgres) database reachable from your localhost on port 5432.
+* The `neo4j` is a [Neo4j](https://neo4j.com/) database reachable from your localhost on port 7474.
 * Config files in the local repo are automatically mapped to where components expect to find them in the Docker environment.
-* Interact with the framework using the client program: `docker compose run --rm amass enum -d owasp.org`
-* You can obtain information about your asset discoveries by accessing the web UI at the following URL: `http://127.0.0.1:3000`
+
+### Usage: Amass Operations
+
+Run Amass subcommands using `docker compose run --rm <service> [args]`. Each service is a one-shot container that connects to the running engine.
+
+**enum** — Perform subdomain enumeration
+
+```bash
+docker compose run --rm enum -d example.com
+docker compose run --rm enum -d example.com -active -brute
+docker compose run --rm enum -alts -d example.com
+```
+
+**subs** — Query discovered subdomains and related data
+
+```bash
+docker compose run --rm subs -d example.com -show
+docker compose run --rm subs -d example.com -names -ip
+```
+
+**assoc** — Walk association triples in the asset graph
+
+```bash
+docker compose run --rm assoc -t1 "example.com has_subdomain *"
+```
+
+**track** — List newly discovered assets
+
+```bash
+docker compose run --rm track -d example.com
+docker compose run --rm track -d example.com -since "01/02 15:04:05 2006 MST"
+```
+
+**viz** — Generate graph visualizations (D3, DOT, GEXF)
+
+```bash
+docker compose run --rm viz -d example.com -d3 -o ./data/viz
+docker compose run --rm viz -d example.com -dot -gexf -oA myresults
+```
+
+### Neo4j Browser
+
+If you set `DB_SERVER=neo4j` in `.env`, you can browse the graph database at [http://127.0.0.1:7474](http://127.0.0.1:7474). Log in with username `neo4j` and the `AMASS_PASSWORD` value from your `.env` file.
+
+### Tips
+
+You can create a shell function to run Amass commands from any directory without typing the full `docker compose run --rm` prefix.
+
+**Linux (Bash)**
+
+Create a file (e.g. `~/.bashrc.d/amass`) with the following content:
+
+```bash
+function amass {
+	docker compose -f <path to amass-docker-compose>/compose.yaml run --rm "$@"
+}
+```
+
+Replace `<path to amass-docker-compose>` with the absolute path to your local repo.
+
+Make it executable: `chmod +x ~/.bashrc.d/amass`
+
+Reload your shell: `source ~/.bashrc.d/amass`
+
+**macOS (Zsh)**
+
+Add the following to your `~/.zshrc`:
+
+```zsh
+function amass {
+	docker compose -f <path to amass-docker-compose>/compose.yaml run --rm "$@"
+}
+```
+
+Replace `<path to amass-docker-compose>` with the absolute path to your local repo.
+
+Reload your shell: `source ~/.zshrc`
+
+**Windows (PowerShell)**
+
+Add the following to your PowerShell profile (`$PROFILE`):
+
+```powershell
+function amass {
+	docker compose -f "<path to amass-docker-compose>\compose.yaml" run --rm @args
+}
+```
+
+Replace `<path to amass-docker-compose>` with the absolute path to your local repo.
+
+Reload your profile: `. $PROFILE`
+
+After reloading, you can run commands like:
+
+```bash
+amass enum -d owasp.org
+amass subs -d owasp.org -names -ip
+```
 
 ### Update Process for the Compose Environment
 
 1. Make the local repo your current working directory: `cd amass-docker-compose`
 2. Shutdown the Amass framework within the Docker environment: `docker compose down`
-3. Backup the `.env`, `config/config.yaml`, and `config/datasources.yaml` files.
-4. Backup the following directories: `assetdb`, `data`, and `logs`
-5. Update the compose local repo with the following command: `git pull origin master`
-6. Restore the files and directories backed up in Steps 3 and 4.
+3. Backup the `assetdb`, `data`, and `logs` directories.
+4. Update the compose local repo with the following command: `git pull origin main`
+
+Your `.env` and `config/datasources.yaml` files are gitignored and will not be affected by `git pull`.
 
 ### Update Process for the Images
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,8 @@ services:
         condition: service_healthy
       syslog:
         condition: service_healthy
+      config-init:
+        condition: service_completed_successfully
     entrypoint: /bin/enum
 
   viz:
@@ -31,6 +33,8 @@ services:
         condition: service_healthy
       syslog:
         condition: service_healthy
+      config-init:
+        condition: service_completed_successfully
     entrypoint: /bin/viz
 
   subs:
@@ -49,6 +53,8 @@ services:
         condition: service_healthy
       syslog:
         condition: service_healthy
+      config-init:
+        condition: service_completed_successfully
     entrypoint: /bin/subs
 
   assoc:
@@ -67,6 +73,8 @@ services:
         condition: service_healthy
       syslog:
         condition: service_healthy
+      config-init:
+        condition: service_completed_successfully
     entrypoint: /bin/assoc
 
   track:
@@ -85,7 +93,17 @@ services:
         condition: service_healthy
       syslog:
         condition: service_healthy
+      config-init:
+        condition: service_completed_successfully
     entrypoint: /bin/track
+
+  config-init:
+    image: alpine:latest
+    secrets:
+      - user_env_file
+    volumes:
+      - ./config:/.config/amass:rw
+    entrypoint: ["/bin/sh", "/.config/amass/config-init.sh"]
 
   engine:
     build: https://github.com/owasp-amass/amass.git#main
@@ -164,6 +182,7 @@ services:
       - ./assetdb/neo4j:/data:rw
     environment:
       - NEO4J_AUTH=neo4j/${AMASS_PASSWORD}
+      - NEO4J_initial_dbms_default__database=${AMASS_DB}
       - NEO4J_server_memory_heap_max__size=4G
     ports:
       - "7474:7474"
@@ -234,3 +253,7 @@ networks:
   amass:
     driver: bridge
     name: amass-net
+
+secrets:
+  user_env_file:
+    file: ./.env

--- a/config/config-init.sh
+++ b/config/config-init.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# Source credentials from Docker secret
+. /run/secrets/user_env_file
+
+cfg=/.config/amass/config.yaml
+
+# Select database: comment out the inactive, uncomment the active
+if [ "${DB_SERVER:-postgres}" = "neo4j" ]; then
+  sed \
+    -e 's|^  database: "postgres://|  # database: "postgres://|' \
+    -e 's|^  # database: "bolt://|  database: "bolt://|' \
+    "$cfg" > /tmp/config.yaml && mv /tmp/config.yaml "$cfg"
+else
+  sed \
+    -e 's|^  database: "bolt://|  # database: "bolt://|' \
+    -e 's|^  # database: "postgres://|  database: "postgres://|' \
+    "$cfg" > /tmp/config.yaml && mv /tmp/config.yaml "$cfg"
+fi
+
+# Substitute credential placeholders from environment
+sed \
+  -e "s|\${AMASS_USER}|$AMASS_USER|g" \
+  -e "s|\${AMASS_PASSWORD}|$AMASS_PASSWORD|g" \
+  -e "s|\${AMASS_DB}|$AMASS_DB|g" \
+  "$cfg" > /tmp/config.yaml && mv /tmp/config.yaml "$cfg"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,10 +21,9 @@ scope:
 options:
   datasources: "./datasources.yaml"
   engine: "http://engine:4000/graphql"
-  # be sure to set your username and password in the following URI to the 
-  # AMASS_USER and AMASS_PASSWORD values, respectively, in your .env file
-  # database: "bolt://neo4j:amass4OWASP@neo4j:7687/neo4j"
-  database: "postgres://amass:amass4OWASP@assetdb:5432/assetdb"
+  # database credentials are substituted from .env at container startup
+  database: "postgres://${AMASS_USER}:${AMASS_PASSWORD}@assetdb:5432/${AMASS_DB}"
+  # database: "bolt://neo4j:${AMASS_PASSWORD}@neo4j:7687/${AMASS_DB}"
   bruteforce:
     enabled: false
     wordlists: # wordlist(s) to use that are specific to brute forcing


### PR DESCRIPTION
Closes #11

## Summary

- **`.env.template`**: Tracked credential template. Users run `cp .env.template .env && chmod 0600 .env`, set `POSTGRES_PASSWORD` and `AMASS_PASSWORD` once, and never touch config files again.

- **`config-init` one-shot service**: Minimal Alpine container that reads credentials from a Docker secret (`.env`) and writes the correct database URI into `config/config.yaml` at every `docker compose up`. All client services (`enum`, `viz`, `subs`, `assoc`, `track`) depend on `config-init: service_completed_successfully`.

- **`DB_SERVER` selector**: `DB_SERVER=neo4j` in `.env` switches the active backend; `config-init` writes the appropriate URI automatically (PostgreSQL default).

- **`NEO4J_initial_dbms_default__database`**: Adds the missing env var so the configured database name is applied at Neo4j init time.

- **`.gitignore` hardening**: Ensures `.env`, `config/config.yaml`, `data/`, `logs/`, and `assetdb/` are gitignored to prevent accidental secret or data commits.

- **README overhaul**: Rewrites setup/usage sections for the new workflow; documents all five subcommand services with examples; adds Neo4j browser instructions and shell function tips for Linux/macOS/Windows; expands update process docs.

## Test plan

- [ ] `cp .env.template .env`, set passwords, run `docker compose up -d` — verify `config-init` completes successfully and engine starts healthy
- [ ] Confirm `config/config.yaml` is populated with the correct database URI and credentials
- [ ] Run `docker compose run --rm enum -d example.com` — verify it connects to engine and produces output
- [ ] Set `DB_SERVER=neo4j` in `.env`, restart, confirm Neo4j URI is written and engine connects to Neo4j
- [ ] Run `docker compose run --rm subs -d example.com -show` — verify query returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)